### PR TITLE
Fix code for modules with longer names.

### DIFF
--- a/bin/pack6
+++ b/bin/pack6
@@ -37,7 +37,7 @@ $os.insert-pos( "module", :last, sub ($os, $dir) {
     note ">> Get module name: [$name]" if $debug;
     note ">> Get module version: [$version]" if $debug;
 
-    my $packname = $name.subst("::", "-") ~ "-{$version}";
+    my $packname = $name.subst("::", "-", :g) ~ "-{$version}";
 
     $outp.add($packname).mkdir;
     note ">> Create pack directory {$packname}" if $debug;


### PR DESCRIPTION
In Line 40 you only replace one "::" with "-" when you put together the name for archive. This breaks when the module has a longer name, like Foo::Bar::Baz;